### PR TITLE
Update package versioning and keywords

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
 			"web/***/**/*"
 		]
 	},
-	"version": "0.1",
+	"version": "0.1.0",
 	"description": "remotewig is a bridge between a web browser and Bitwig.",
 	"author": "J28",
 	"homepage": "http://stoyanvasilev.me/",

--- a/app/web/package.json
+++ b/app/web/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "remotewig-web",
-	"version": "0.1",
-	"ignore": [],
+	"version": "0.1.0",
 	"dependencies": {
 		"osc": "2.4.0"
 	}


### PR DESCRIPTION
[The NPM docs for package.json ](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#version) state that "Version must be parseable by node-semver, which is bundled with npm as a dependency. (npm install semver to use it yourself.)"

I haven't yet tested whether this happens on macOS, but on Windows when using a version number of "0.1" `npm install` will just fail silently. It won't create a node_modules directory, but will create a package-lock.json. It's a very annoying bug and is easily remedied by adhering to [semver](https://semver.org/).

Additionally, I removed the ignore keyword in the /app/web/package.json because it doesn't appear to be doing anything and is not a valid keyword listed in the linked documentation.
Lastly, readmeFilename in app/package.json isn't a valid keyword according to the linked docs, but it's not harming anything so I didn't remove it.

